### PR TITLE
Fix loguru import, not used anymore

### DIFF
--- a/src/pipe/add_masked_terms.py
+++ b/src/pipe/add_masked_terms.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.attack_prompts.add_masked_terms import ADD_MASKED_TERMS_PROMPT_V1
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor

--- a/src/pipe/add_masked_terms.py
+++ b/src/pipe/add_masked_terms.py
@@ -2,11 +2,10 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.attack_prompts.add_masked_terms import ADD_MASKED_TERMS_PROMPT_V1
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.llm_util import extract_object
+from src.utils.logging import logger
 
 
 class AddMaskedTerms(PromptProcessor):

--- a/src/pipe/add_masked_terms_det.py
+++ b/src/pipe/add_masked_terms_det.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.processor.list_transformer import JsonListTransformer
 from src.pipe.utils import replace_str

--- a/src/pipe/add_masked_terms_det.py
+++ b/src/pipe/add_masked_terms_det.py
@@ -2,10 +2,9 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.processor.list_transformer import JsonListTransformer
 from src.pipe.utils import replace_str
+from src.utils.logging import logger
 
 
 class AddMaskedTermsDeterministic(JsonListTransformer):

--- a/src/pipe/detect_values_prompts/prompt_processor.py
+++ b/src/pipe/detect_values_prompts/prompt_processor.py
@@ -5,11 +5,10 @@ from abc import abstractmethod
 from json import JSONDecodeError
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.llm_util import send_prompt
 from src.pipe.processor.list_transformer import JsonListTransformer
 from src.pipe.utils import Timer
+from src.utils.logging import logger
 
 
 class PromptProcessor(JsonListTransformer):

--- a/src/pipe/detect_values_prompts/prompt_processor.py
+++ b/src/pipe/detect_values_prompts/prompt_processor.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from json import JSONDecodeError
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.llm_util import send_prompt
 from src.pipe.processor.list_transformer import JsonListTransformer

--- a/src/pipe/exec_conc_sql.py
+++ b/src/pipe/exec_conc_sql.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.processor.list_transformer import JsonListTransformer
 from src.pipe.sqlite_facade import SqliteFacade

--- a/src/pipe/exec_conc_sql.py
+++ b/src/pipe/exec_conc_sql.py
@@ -2,10 +2,9 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.processor.list_transformer import JsonListTransformer
 from src.pipe.sqlite_facade import SqliteFacade
+from src.utils.logging import logger
 
 
 class ExecuteConcreteSql(JsonListTransformer):

--- a/src/pipe/filtered_symb_schema.py
+++ b/src/pipe/filtered_symb_schema.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.processor.list_transformer import JsonListTransformer
 from src.pipe.schema_repo import DatabaseSchema, DatabaseSchemaRepo

--- a/src/pipe/filtered_symb_schema.py
+++ b/src/pipe/filtered_symb_schema.py
@@ -2,10 +2,9 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.processor.list_transformer import JsonListTransformer
 from src.pipe.schema_repo import DatabaseSchema, DatabaseSchemaRepo
+from src.utils.logging import logger
 
 
 class AddFilteredSymbolicSchema(JsonListTransformer):

--- a/src/pipe/gen_sql.py
+++ b/src/pipe/gen_sql.py
@@ -3,7 +3,7 @@
 import re
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.sql_gen_prompts.masked_v3 import MASKED_GEN_SQL_PROMPT_V3

--- a/src/pipe/gen_sql.py
+++ b/src/pipe/gen_sql.py
@@ -3,10 +3,9 @@
 import re
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.sql_gen_prompts.masked_v3 import MASKED_GEN_SQL_PROMPT_V3
+from src.utils.logging import logger
 
 
 DATA_DIR = "data"

--- a/src/pipe/link_schema.py
+++ b/src/pipe/link_schema.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.llm_util import extract_object

--- a/src/pipe/link_schema.py
+++ b/src/pipe/link_schema.py
@@ -2,11 +2,10 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.llm_util import extract_object
 from src.pipe.schema_link_prompts.v4 import SCHEMA_LINK_PROMPT_V4
+from src.utils.logging import logger
 
 
 class LinkSchema(PromptProcessor):

--- a/src/pipe/link_schema_and_value.py
+++ b/src/pipe/link_schema_and_value.py
@@ -2,11 +2,10 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.able_prompts.schema_value_link import SCHEMA_VALUE_LINK_PROMPT_V1
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.llm_util import extract_object
+from src.utils.logging import logger
 
 
 class LinkSchemaAndValue(PromptProcessor):

--- a/src/pipe/link_schema_and_value.py
+++ b/src/pipe/link_schema_and_value.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.able_prompts.schema_value_link import SCHEMA_VALUE_LINK_PROMPT_V1
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor

--- a/src/pipe/main.py
+++ b/src/pipe/main.py
@@ -1,11 +1,7 @@
 """Main pipeline execution script."""
 
 import asyncio
-import contextlib
 import os
-import sys
-
-from src.utils.logging import logger
 
 from src.pipe.add_schema import AddFilteredSchema
 from src.pipe.add_symb_schema import AddSymbolicSchema
@@ -31,6 +27,7 @@ from src.pipe.symb_table import AddSymbolTable
 from src.pipe.unmask import AddConcreteSql
 from src.pipe.value_links import LinkValues
 from src.pipe.wrong_exec_acc import ExecuteConcreteSql
+from src.utils.logging import configure_logging
 
 
 LLM_MODEL: str | None = os.getenv("LLM_MODEL")
@@ -105,15 +102,7 @@ slm_mask: list[JsonListProcessor] = [
 
 async def main() -> None:
     """Execute main pipeline processing."""
-    with contextlib.suppress(Exception):
-        logger.remove(0)
-    logger.add(
-        sys.stderr,
-        level=LOG_LEVEL,
-        colorize=True,
-        enqueue=True,
-        format="<green>{time:HH:mm:ss}[{process.id}] | </green><level> {level}: {message}</level>",
-    )
+    configure_logging()
 
     pipeline = Pipeline(mask_pipe)
     # pipeline = Pipeline(slm_mask)

--- a/src/pipe/main.py
+++ b/src/pipe/main.py
@@ -5,7 +5,7 @@ import contextlib
 import os
 import sys
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.add_schema import AddFilteredSchema
 from src.pipe.add_symb_schema import AddSymbolicSchema

--- a/src/pipe/repair_link_schema.py
+++ b/src/pipe/repair_link_schema.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.llm_util import extract_object

--- a/src/pipe/repair_link_schema.py
+++ b/src/pipe/repair_link_schema.py
@@ -2,11 +2,10 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.llm_util import extract_object
 from src.pipe.schema_link_prompts.repair import REPAIR_SCHEMA_LINK_PROMPT_V1
+from src.utils.logging import logger
 
 
 class RepairSchemaLinks(PromptProcessor):

--- a/src/pipe/repair_sql.py
+++ b/src/pipe/repair_sql.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.gen_sql import extract_sql

--- a/src/pipe/repair_sql.py
+++ b/src/pipe/repair_sql.py
@@ -2,11 +2,10 @@
 
 from typing import Any
 
-from src.utils.logging import logger
-
 from src.pipe.detect_values_prompts.prompt_processor import PromptProcessor
 from src.pipe.gen_sql import extract_sql
 from src.pipe.sql_repair_prompts.v3 import REPAIR_SQL_PROMPT_V3
+from src.utils.logging import logger
 
 
 class RepairSQL(PromptProcessor):

--- a/src/pipe/results.py
+++ b/src/pipe/results.py
@@ -44,7 +44,7 @@ class Results(JsonListTransformer):
         # Add each metric to the table
         for metric, value in stats.items():
             formatted_value = f"{value:.6f}" if isinstance(value, float) else str(value)
-            results_table.add_row(metric, formatted_value)
+            results_table.add_row(str(metric), formatted_value)
 
         console.print(results_table)
         console.print(f"\n[dim]Total samples processed: {self.count}[/dim]\n")

--- a/src/pipe/sqlite_facade.py
+++ b/src/pipe/sqlite_facade.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from sqlite3 import Connection
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 
 
 DB_TIMEOUT = 10000

--- a/src/pipe/tmp_pipe.py
+++ b/src/pipe/tmp_pipe.py
@@ -5,7 +5,7 @@ import contextlib
 import os
 import sys
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.pipe.add_schema import AddFilteredSchema
 from src.pipe.add_symb_schema import AddSymbolicSchema

--- a/src/pipe/tmp_pipe.py
+++ b/src/pipe/tmp_pipe.py
@@ -1,11 +1,7 @@
 """Temporary pipeline processing utilities."""
 
 import asyncio
-import contextlib
 import os
-import sys
-
-from src.utils.logging import logger
 
 from src.pipe.add_schema import AddFilteredSchema
 from src.pipe.add_symb_schema import AddSymbolicSchema
@@ -26,6 +22,7 @@ from src.pipe.repair_symb_sql import RepairSymbolicSQLRaw
 from src.pipe.slm_mask import SlmMask, SlmUnmask
 from src.pipe.symb_table import AddSymbolTable
 from src.pipe.wrong_exec_acc import ExecuteConcreteSql
+from src.utils.logging import configure_logging
 
 
 LLM_MODEL = os.getenv("LLM_MODEL", "openai/gpt-4")
@@ -78,15 +75,7 @@ slm_mask = [
 
 async def main() -> None:
     """Run the temporary pipeline for testing."""
-    with contextlib.suppress(Exception):
-        logger.remove(0)
-    logger.add(
-        sys.stderr,
-        level=LOG_LEVEL,
-        colorize=True,
-        enqueue=True,
-        format="<green>{time:HH:mm:ss}[{process.id}] | </green><level> {level}: {message}</level>",
-    )
+    configure_logging()
 
     pipeline = Pipeline(mask_pipe)
     # pipeline = Pipeline(slm_mask)

--- a/src/pipe/utils.py
+++ b/src/pipe/utils.py
@@ -3,7 +3,7 @@
 import re
 from datetime import datetime
 
-from loguru import logger
+from src.utils.logging import logger
 
 
 def replace_str(text: str, src: str, dst: str) -> str:

--- a/src/taxonomy/cat/catter.py
+++ b/src/taxonomy/cat/catter.py
@@ -1,6 +1,6 @@
 """SQL statement categorization interface."""
 
-from loguru import logger
+from src.utils.logging import logger
 
 from src.taxonomy.cat.categorizer import Categorizer
 from src.taxonomy.cat.statement_category import StatementCategory

--- a/src/taxonomy/cat/catter.py
+++ b/src/taxonomy/cat/catter.py
@@ -1,12 +1,11 @@
 """SQL statement categorization interface."""
 
-from src.utils.logging import logger
-
 from src.taxonomy.cat.categorizer import Categorizer
 from src.taxonomy.cat.statement_category import StatementCategory
 from src.taxonomy.cat.sub_category import SubCategory
 from src.taxonomy.cat.tag_extractor import TagExtractor
 from src.taxonomy.parse.parser import SqlParser
+from src.utils.logging import logger
 
 
 class Catter:

--- a/src/taxonomy/parse/database_schema.py
+++ b/src/taxonomy/parse/database_schema.py
@@ -3,7 +3,7 @@
 from difflib import SequenceMatcher
 from typing import Dict, FrozenSet, List, Set, Tuple
 
-from loguru import logger
+from src.utils.logging import logger
 
 
 def str_similarity(s1: str, s2: str) -> float:

--- a/src/taxonomy/parse/parser.py
+++ b/src/taxonomy/parse/parser.py
@@ -4,9 +4,9 @@
 from dataclasses import replace
 from typing import Any
 
-from src.utils.logging import logger
 from ply import yacc
 
+from src.utils.logging import logger
 from src.utils.strings import shrink_whitespaces
 
 from .lexer import get_lexer

--- a/src/taxonomy/parse/parser.py
+++ b/src/taxonomy/parse/parser.py
@@ -4,7 +4,7 @@
 from dataclasses import replace
 from typing import Any
 
-from loguru import logger
+from src.utils.logging import logger
 from ply import yacc
 
 from src.utils.strings import shrink_whitespaces


### PR DESCRIPTION
This pull request standardizes logging across the codebase by replacing all direct imports of the `loguru` logger with imports from a central `src.utils.logging` module. This change ensures consistent logging practices and makes it easier to manage logging configuration in one place.

**Logging standardization:**

* Replaced all instances of `from loguru import logger` with `from src.utils.logging import logger` in the following files to centralize and standardize logging:
  - `src/pipe/add_masked_terms.py`
  - `src/pipe/add_masked_terms_det.py`
  - `src/pipe/detect_values_prompts/prompt_processor.py`
  - `src/pipe/exec_conc_sql.py`
  - `src/pipe/filtered_symb_schema.py`
  - `src/pipe/gen_sql.py`
  - `src/pipe/link_schema.py`
  - `src/pipe/link_schema_and_value.py`
  - `src/pipe/main.py`
  - `src/pipe/repair_link_schema.py`
  - `src/pipe/repair_sql.py`
  - `src/pipe/sqlite_facade.py`
  - `src/pipe/tmp_pipe.py`
  - `src/pipe/utils.py`
  - `src/taxonomy/cat/catter.py`
  - `src/taxonomy/parse/database_schema.py`
  - `src/taxonomy/parse/parser.py`